### PR TITLE
feat: "pleb upgrade" special-cases @types/node

### DIFF
--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -29,7 +29,9 @@ export async function upgrade({ directoryPath, registryUrl, dryRun }: UpgradeOpt
       [...Object.entries(dependencies), ...Object.entries(devDependencies)]
         .filter(
           ([packageName, packageVersion]) =>
-            !internalPackageNames.has(packageName) && !isFileColonRequest(packageVersion)
+            !internalPackageNames.has(packageName) &&
+            !isFileColonRequest(packageVersion) &&
+            !(packageName === '@types/node' && isPureNumericRequest(packageVersion))
         )
         .map(([packageName]) => packageName)
     )
@@ -117,4 +119,20 @@ export async function fetchLatestPackageVersions({
 
 function isFileColonRequest(request: string) {
   return request.startsWith('file:');
+}
+
+function isPureNumericRequest(request: string) {
+  if (!request.length) {
+    return false;
+  }
+  for (const character of request) {
+    if (!isDigit(character)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function isDigit(c: string) {
+  return c >= '0' && c <= '9';
 }


### PR DESCRIPTION
if @types/node has a numeric-only request (e.g. "12"), it will ignore it and not upgrade. this allows `"@types/node": "10"` to be kept as-is.
while a configuration file could (or should) be introduced, the aim is to avoid repetitive project-specific config and have better default behavior for the existing ecosystem.