### PR TITLE
fix: always publish in correct dependency order

### DIFF
--- a/src/utils/npm-package.ts
+++ b/src/utils/npm-package.ts
@@ -73,16 +73,18 @@ export function sortPackagesByDepth(packages: INpmPackage[]): INpmPackage[] {
     ])
   );
 
-  packages = [...packages]; // .sort() mutates original array, yet we prefer immutability
-  packages.sort((package1, package2) => {
-    if (packageToDeepDeps.get(package2)!.has(package1)) {
-      return -1;
-    } else if (packageToDeepDeps.get(package1)!.has(package2)) {
-      return 1;
-    } else {
-      return 0;
-    }
-  });
+  const sortedPackages: INpmPackage[] = [];
 
-  return packages;
+  for (const npmPackage of packages) {
+    const dependingPackageIdx = sortedPackages.findIndex((sortedPackage) =>
+      packageToDeepDeps.get(sortedPackage)!.has(npmPackage)
+    );
+    if (dependingPackageIdx === -1) {
+      sortedPackages.push(npmPackage);
+    } else {
+      sortedPackages.splice(dependingPackageIdx, 0, npmPackage);
+    }
+  }
+
+  return sortedPackages;
 }

--- a/test/sort-packages.spec.ts
+++ b/test/sort-packages.spec.ts
@@ -1,0 +1,29 @@
+import { expect } from 'chai';
+import { INpmPackage, sortPackagesByDepth } from '../src/utils/npm-package';
+
+describe('sortPackagesByDepth', () => {
+  const createPackage = (packageName: string, dependencies?: Record<string, string>): INpmPackage => ({
+    displayName: packageName,
+    packageJson: { name: packageName, dependencies },
+    directoryPath: '/',
+    packageJsonContent: ``,
+    packageJsonPath: '/',
+  });
+
+  it('sorts two packages depending on one another', () => {
+    const packageA = createPackage('packageA', { packageB: '1.0.0' });
+    const packageB = createPackage('packageB');
+    const sorted = sortPackagesByDepth([packageA, packageB]);
+    expect(sorted.map((s) => s.displayName)).to.eql(['packageB', 'packageA']);
+  });
+
+  it('sorts several packages with isolated packages in the middle', () => {
+    const packageA = createPackage('packageA', { packageB: '1.0.0' });
+    const packageB = createPackage('packageB', { packageC: '1.0.0' });
+    const packageC = createPackage('packageC');
+    const packageD = createPackage('packageD');
+
+    const sorted = sortPackagesByDepth([packageA, packageD, packageB, packageC]);
+    expect(sorted.map((s) => s.displayName)).to.eql(['packageC', 'packageB', 'packageA', 'packageD']);
+  });
+});


### PR DESCRIPTION
- isolated packages not depending on any other in the repo could have caused the previous toposort to fail. newer sorting now handles such cases.
- added regression units to sorting functionality.