### PR TITLE
feat!: migrate package to native esm

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,6 +5,9 @@
   },
   "extends": ["eslint:recommended", "prettier"],
   "plugins": ["no-only-tests"],
+  "parserOptions": {
+    "sourceType": "module"
+  },
   "rules": {
     "no-only-tests/no-only-tests": "error",
     "no-console": "error"

--- a/.mocharc.cjs
+++ b/.mocharc.cjs
@@ -1,6 +1,5 @@
 module.exports = {
-  require: ['@ts-tools/node/r'],
+  'node-option': ['loader=@ts-tools/esm'],
   extension: ['js', 'json', 'ts', 'tsx'],
   colors: true,
-  timeout: 30000,
 };

--- a/bin/pleb.js
+++ b/bin/pleb.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-require('../dist/cli');
+import '../dist/cli.js';

--- a/package-lock.json
+++ b/package-lock.json
@@ -156,20 +156,10 @@
         "fastq": "^1.6.0"
       }
     },
-    "@ts-tools/node": {
+    "@ts-tools/esm": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@ts-tools/node/-/node-3.0.1.tgz",
-      "integrity": "sha512-8SQNZomZYs03AP9LR2jxuZanpviBgJRglIh5OB7tS4Dt4TkgzxmgtciMSaKuDac7Q+ptyiq0GcUDvmXaXRle6A==",
-      "dev": true,
-      "requires": {
-        "@ts-tools/transpile": "^3.0.1",
-        "source-map-support": "^0.5.19"
-      }
-    },
-    "@ts-tools/transpile": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@ts-tools/transpile/-/transpile-3.0.1.tgz",
-      "integrity": "sha512-PxM/8aIPN9IEJxu0RI9F7M1lUGVRC+ZW/TBnL73U3oQiGeyNsk6EfvzDP4bvCPSUUVByXYCpaofFQAHvlLRwAQ==",
+      "resolved": "https://registry.npmjs.org/@ts-tools/esm/-/esm-3.0.1.tgz",
+      "integrity": "sha512-yUb64hyUpXScOJN2OCiIoxnC2w7Fd7LdkcpGSn4W3pyXGNZb65r8sClnU/070c3Pqfkb5By4Fg6D4Y4F6wTXKg==",
       "dev": true
     },
     "@types/chai": {
@@ -299,6 +289,17 @@
         "glob": "^7.1.7",
         "tslib": "^2.3.1",
         "type-fest": "^2.1.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        }
       }
     },
     "acorn": {
@@ -415,12 +416,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-      "dev": true
-    },
-    "buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
     "callsites": {
@@ -851,12 +846,48 @@
       }
     },
     "find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.0.0.tgz",
+      "integrity": "sha512-NU20P/qRR4fbjbfQgf5SL6L7AbQbUG69OmBJ3o+DEmHwSwKaaeZ+9ok/zuE5Z8pyFSGPerTen16gLZTs1v1zjQ==",
       "requires": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
+        "locate-path": "^7.0.0",
+        "path-exists": "^5.0.0"
+      },
+      "dependencies": {
+        "locate-path": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.0.0.tgz",
+          "integrity": "sha512-+cg2yXqDUKfo4hsFxwa3G1cBJeA+gs1vD8FyV9/odWoUlQe/4syxHQ5DPtKjtfm6gnKbZzjCqzX03kXosvZB1w==",
+          "requires": {
+            "p-locate": "^6.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+          "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+          "requires": {
+            "yocto-queue": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+          "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+          "requires": {
+            "p-limit": "^4.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+          "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ=="
+        },
+        "yocto-queue": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+          "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g=="
+        }
       }
     },
     "flat": {
@@ -912,9 +943,9 @@
       "dev": true
     },
     "glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1233,6 +1264,30 @@
             }
           }
         },
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.7",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "js-yaml": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -1305,11 +1360,6 @@
         "word-wrap": "^1.2.3"
       }
     },
-    "p-finally": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
-    },
     "p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -1327,21 +1377,18 @@
       }
     },
     "p-queue": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
-      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.1.0.tgz",
+      "integrity": "sha512-V+0vPJbhYkBqknPp0qnaz+dWcj8cNepfXZcsVIVEHPbFQXMPwrzCNIiM4FoxGtwHXtPzVCPHDvqCr1YrOJX2Gw==",
       "requires": {
-        "eventemitter3": "^4.0.4",
-        "p-timeout": "^3.2.0"
+        "eventemitter3": "^4.0.7",
+        "p-timeout": "^5.0.0"
       }
     },
     "p-timeout": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
-      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
-      "requires": {
-        "p-finally": "^1.0.0"
-      }
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.0.0.tgz",
+      "integrity": "sha512-z+bU/N7L1SABsqKnQzvAnINgPX7NHdzwUV+gHyJE7VGNDZSr03rhcPODCZSWiiT9k+gf74QPmzcZzqJRvxYZow=="
     },
     "parent-module": {
       "version": "1.0.1",
@@ -1534,22 +1581,6 @@
         "ansi-styles": "^4.0.0",
         "astral-regex": "^2.0.0",
         "is-fullwidth-code-point": "^3.0.0"
-      }
-    },
-    "source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true
-    },
-    "source-map-support": {
-      "version": "0.5.20",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.20.tgz",
-      "integrity": "sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==",
-      "dev": true,
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
       }
     },
     "sprintf-js": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "pleb",
   "description": "a casual publisher",
   "version": "3.4.5",
-  "main": "dist/index.js",
+  "type": "module",
+  "exports": {
+    ".": "./dist/index.js"
+  },
   "types": "dist/index.d.ts",
   "bin": {
     "pleb": "bin/pleb.js"
@@ -11,7 +14,7 @@
     "clean": "rimraf ./dist",
     "prebuild": "npm run clean",
     "build": "tsc -p tsconfig.build.json",
-    "pretest": "npm run typecheck && npm run lint",
+    "pretest": "npm run typecheck && npm run lint && npm run build",
     "test": "npm run test:spec",
     "test:spec": "mocha \"./test/**/*.spec.ts\"",
     "lint": "eslint . -f codeframe",
@@ -23,15 +26,15 @@
     "@wixc3/resolve-directory-context": "^1.0.1",
     "chalk": "^4.1.2",
     "commander": "^8.2.0",
-    "find-up": "^5.0.0",
-    "p-queue": "^6.6.2",
+    "find-up": "^6.0.0",
+    "p-queue": "^7.1.0",
     "promise-assist": "^1.3.0",
     "semver": "^7.3.5",
     "tslib": "^2.3.1",
     "type-fest": "^2.3.4"
   },
   "devDependencies": {
-    "@ts-tools/node": "^3.0.1",
+    "@ts-tools/esm": "^3.0.1",
     "@types/chai": "^4.2.22",
     "@types/mocha": "^9.0.0",
     "@types/node": "12",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,11 +1,13 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import fs from 'fs';
 import path from 'path';
+import { URL } from 'url';
 import { Command } from 'commander';
 import type { PackageJson } from 'type-fest';
-import { reportProcessError } from './utils/process';
+import { reportProcessError } from './utils/process.js';
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const { name, version, description } = require('../package.json') as PackageJson;
+const packageJsonPath = new URL('../package.json', import.meta.url);
+const { name, version, description } = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as PackageJson;
 
 process.on('unhandledRejection', reportProcessError);
 process.on('uncaughtException', reportProcessError);
@@ -20,7 +22,7 @@ program
   .option('--tag <tag>', 'tag to use for published version', 'latest')
   .action(async (targetPath: string, { dryRun, contents, registry, tag }) => {
     try {
-      const { publish } = await import('./commands/publish');
+      const { publish } = await import('./commands/publish.js');
 
       await publish({
         directoryPath: path.resolve(targetPath || ''),
@@ -41,7 +43,7 @@ program
   .option('--registry <url>', 'npm registry to use')
   .action(async (targetPath: string, { dryRun, registry }) => {
     try {
-      const { upgrade } = await import('./commands/upgrade');
+      const { upgrade } = await import('./commands/upgrade.js');
 
       await upgrade({
         directoryPath: path.resolve(targetPath || ''),

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -7,11 +7,11 @@ import {
   executePrepublishScripts,
   removePrepublishScripts,
   getPackagesToPublish,
-} from '../utils/npm-publish';
-import { uriToIdentifier, NpmRegistry, officialNpmRegistryUrl } from '../utils/npm-registry';
-import { loadEnvNpmConfig } from '../utils/npm-config';
-import { log } from '../utils/log';
-import { spawnSyncLogged } from '../utils/process';
+} from '../utils/npm-publish.js';
+import { uriToIdentifier, NpmRegistry, officialNpmRegistryUrl } from '../utils/npm-registry.js';
+import { loadEnvNpmConfig } from '../utils/npm-config.js';
+import { log } from '../utils/log.js';
+import { spawnSyncLogged } from '../utils/process.js';
 
 export interface PublishOptions {
   directoryPath: string;

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -1,12 +1,14 @@
 /* eslint-disable no-console */
 import fs from 'fs';
 import PromiseQueue from 'p-queue';
-import { gt, coerce } from 'semver';
+import semver from 'semver';
 import { resolveDirectoryContext, allPackagesFromContext, isString } from '@wixc3/resolve-directory-context';
-import { createCliProgressBar } from '../utils/cli-progress-bar';
-import { uriToIdentifier, officialNpmRegistryUrl, NpmRegistry } from '../utils/npm-registry';
-import { loadEnvNpmConfig } from '../utils/npm-config';
-import { mapRecord } from '../utils/language-helpers';
+import { createCliProgressBar } from '../utils/cli-progress-bar.js';
+import { uriToIdentifier, officialNpmRegistryUrl, NpmRegistry } from '../utils/npm-registry.js';
+import { loadEnvNpmConfig } from '../utils/npm-config.js';
+import { mapRecord } from '../utils/language-helpers.js';
+
+const { gt, coerce } = semver;
 
 export interface UpgradeOptions {
   directoryPath: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export * from './commands/publish';
-export * from './commands/upgrade';
+export * from './commands/publish.js';
+export * from './commands/upgrade.js';

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -1,4 +1,6 @@
-import { green, yellow, red } from 'chalk';
+import chalk from 'chalk';
+
+const { green, yellow, red } = chalk;
 
 /* eslint-disable no-console */
 export const log = (message: unknown): void => console.log(`${green('#')} ${String(message)}`);

--- a/src/utils/npm-config.ts
+++ b/src/utils/npm-config.ts
@@ -1,9 +1,9 @@
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import findUp from 'find-up';
-import { parseIni } from './ini';
-import { fileExists } from './fs';
+import { findUp } from 'find-up';
+import { parseIni } from './ini.js';
+import { fileExists } from './fs.js';
 
 export interface LoadNpmConfigOptions {
   basePath?: string;

--- a/src/utils/npm-publish.ts
+++ b/src/utils/npm-publish.ts
@@ -3,9 +3,9 @@ import type childProcess from 'child_process';
 import { retry } from 'promise-assist';
 import type { PackageJson } from 'type-fest';
 import { INpmPackage, isString, isPlainObject } from '@wixc3/resolve-directory-context';
-import type { NpmRegistry } from './npm-registry';
-import { spawnSyncLogged } from './process';
-import { logWarn, log } from './log';
+import type { NpmRegistry } from './npm-registry.js';
+import { spawnSyncLogged } from './process.js';
+import { logWarn, log } from './log.js';
 
 export async function getPackagesToPublish(packages: INpmPackage[], registry: NpmRegistry): Promise<INpmPackage[]> {
   const packagesToPublish: INpmPackage[] = [];

--- a/src/utils/npm-registry.ts
+++ b/src/utils/npm-registry.ts
@@ -3,7 +3,7 @@ import http from 'http';
 import https from 'https';
 import { URL } from 'url';
 import { isPlainObject } from '@wixc3/resolve-directory-context';
-import { fetchText, isSecureUrl, FetchError } from './http';
+import { fetchText, isSecureUrl, FetchError } from './http.js';
 
 export const officialNpmRegistryUrl = 'https://registry.npmjs.org/';
 

--- a/src/utils/process.ts
+++ b/src/utils/process.ts
@@ -1,5 +1,5 @@
 import { spawnSync, SpawnSyncOptions, SpawnSyncReturns } from 'child_process';
-import { log, logError } from './log';
+import { log, logError } from './log.js';
 
 export const spawnSyncSafe = ((...args: Parameters<typeof spawnSync>) => {
   const spawnResult = spawnSync(...args);

--- a/test/cli.spec.ts
+++ b/test/cli.spec.ts
@@ -1,17 +1,19 @@
 import { join } from 'path';
+import { fileURLToPath, URL } from 'url';
 import { expect } from 'chai';
-import { spawnAsync } from './spawn-async';
+import { spawnAsync } from './spawn-async.js';
 
-const fixturesRoot = join(__dirname, 'fixtures');
-
-const cliEntryPath = require.resolve('../src/cli.ts');
+const fixturesRoot = fileURLToPath(new URL('./fixtures', import.meta.url));
+const cliEntryPath = fileURLToPath(new URL('../bin/pleb.js', import.meta.url));
 
 const runCli = async (cliArgs: string[] = []) =>
-  spawnAsync('node', ['-r', '@ts-tools/node/r', cliEntryPath, ...cliArgs, '--dry-run'], {
+  spawnAsync('node', [cliEntryPath, ...cliArgs, '--dry-run'], {
     pipeStreams: true,
   });
 
-describe('cli', () => {
+describe('cli', function () {
+  this.timeout(30_000);
+
   describe('publish', () => {
     it('allows publishing new (not published) packages', async () => {
       const newPackagePath = join(fixturesRoot, 'new-package');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
     "target": "es2019",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
-    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    "module": "esnext",                       /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     "lib": [
       "es2019"
     ],                                        /* Specify library files to be included in the compilation. */


### PR DESCRIPTION
- latest node 12/14/16 versions are supporting it
- allows upgrading to latest versions of some dependencies, which already migrated
- tests are now actually running against the built package, instead of its sources