### PR TITLE
docs: fix jsdoc type example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ e.g.:
 ```js
 // pleb.config.mjs
 
-/** @type import('pleb').Configuration */
+/** @type import('pleb').PlebConfiguration */
 export default {
   pinnedPackages: ['react', 'react-dom', { name: 'execa', reason: 'newer version are pure ESM' }],
 };


### PR DESCRIPTION
The example uses an incorrect type symbol.
It should be `PlebConfiguration`.