### PR TITLE
refactor: prepare running tests from src

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import fs from 'node:fs';
 import path from 'node:path';
 import type { PackageJson } from 'type-fest';
-import { reportProcessError } from './utils/process.js';
+import { reportProcessError } from './utils/process.ts';
 
 const packageJsonPath = new URL('../package.json', import.meta.url);
 const { name, version, description } = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as PackageJson;

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -2,11 +2,11 @@ import { childPackagesFromContext, resolveDirectoryContext } from '@wixc3/resolv
 import type { SpawnSyncOptions } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
-import { log } from '../utils/log.js';
-import { loadEnvNpmConfig } from '../utils/npm-config.js';
-import { getPackagesToPublish } from '../utils/npm-publish.js';
-import { NpmRegistry, officialNpmRegistryUrl, uriToIdentifier } from '../utils/npm-registry.js';
-import { spawnSyncLogged } from '../utils/process.js';
+import { log } from '../utils/log.ts';
+import { loadEnvNpmConfig } from '../utils/npm-config.ts';
+import { getPackagesToPublish } from '../utils/npm-publish.ts';
+import { NpmRegistry, officialNpmRegistryUrl, uriToIdentifier } from '../utils/npm-registry.ts';
+import { spawnSyncLogged } from '../utils/process.ts';
 
 export interface PublishOptions {
   directoryPath: string;

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -4,10 +4,10 @@ import fs from 'node:fs';
 import path from 'node:path';
 import PromiseQueue from 'p-queue';
 import semver from 'semver';
-import { createCliProgressBar } from '../utils/cli-progress-bar.js';
-import { loadPlebConfig, normalizePinnedPackages } from '../utils/config.js';
-import { loadEnvNpmConfig } from '../utils/npm-config.js';
-import { NpmRegistry, officialNpmRegistryUrl, uriToIdentifier } from '../utils/npm-registry.js';
+import { createCliProgressBar } from '../utils/cli-progress-bar.ts';
+import { loadPlebConfig, normalizePinnedPackages } from '../utils/config.ts';
+import { loadEnvNpmConfig } from '../utils/npm-config.ts';
+import { NpmRegistry, officialNpmRegistryUrl, uriToIdentifier } from '../utils/npm-registry.ts';
 
 const { gt, coerce } = semver;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export * from './commands/publish.js';
-export * from './commands/upgrade.js';
-export type { Configuration as PlebConfiguration, SkipConfiguration } from './utils/config.js';
+export * from './commands/publish.ts';
+export * from './commands/upgrade.ts';
+export type { Configuration as PlebConfiguration, SkipConfiguration } from './utils/config.ts';

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -30,12 +30,11 @@ export function isSecureUrl(url: string | URL): boolean {
 }
 
 export class FetchError extends Error {
-  constructor(
-    message?: string,
-    public statusCode?: number,
-  ) {
+  public statusCode;
+  constructor(message?: string, statusCode?: number) {
     super(message);
     // https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html#support-for-newtarget
     Object.setPrototypeOf(this, new.target.prototype);
+    this.statusCode = statusCode;
   }
 }

--- a/src/utils/npm-config.ts
+++ b/src/utils/npm-config.ts
@@ -2,8 +2,8 @@ import { findFileUpSync } from '@wixc3/resolve-directory-context';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { fileExists } from './fs.js';
-import { parseIni } from './ini.js';
+import { fileExists } from './fs.ts';
+import { parseIni } from './ini.ts';
 
 export interface LoadNpmConfigOptions {
   basePath?: string;

--- a/src/utils/npm-publish.ts
+++ b/src/utils/npm-publish.ts
@@ -1,7 +1,7 @@
 import { type INpmPackage } from '@wixc3/resolve-directory-context';
 import { retry } from 'promise-assist';
-import { log, logWarn } from './log.js';
-import type { NpmRegistry } from './npm-registry.js';
+import { log, logWarn } from './log.ts';
+import type { NpmRegistry } from './npm-registry.ts';
 
 export async function getPackagesToPublish(packages: INpmPackage[], registry: NpmRegistry): Promise<INpmPackage[]> {
   const packagesToPublish: INpmPackage[] = [];

--- a/src/utils/npm-registry.ts
+++ b/src/utils/npm-registry.ts
@@ -1,7 +1,7 @@
 import { isPlainObject } from '@wixc3/resolve-directory-context';
 import http from 'node:http';
 import https from 'node:https';
-import { FetchError, fetchText, isSecureUrl } from './http.js';
+import { FetchError, fetchText, isSecureUrl } from './http.ts';
 
 export const officialNpmRegistryUrl = 'https://registry.npmjs.org/';
 
@@ -12,10 +12,12 @@ export interface NpmRegistryDistTags {
 
 export class NpmRegistry {
   agent?: http.Agent | https.Agent;
-  constructor(
-    public url: string,
-    private token?: string,
-  ) {}
+  public url;
+  private token;
+  constructor(url: string, token?: string) {
+    this.url = url;
+    this.token = token;
+  }
 
   public async fetchDistTags(packageName: string): Promise<NpmRegistryDistTags> {
     this.ensureAgent();

--- a/src/utils/process.ts
+++ b/src/utils/process.ts
@@ -1,5 +1,5 @@
 import { spawnSync, type SpawnSyncOptions, type SpawnSyncReturns } from 'node:child_process';
-import { log, logError } from './log.js';
+import { log, logError } from './log.ts';
 
 export const spawnSyncSafe = ((...args: Parameters<typeof spawnSync>) => {
   const spawnResult = spawnSync(...args);

--- a/test/publish.test.ts
+++ b/test/publish.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
-import { spawnAsync } from './spawn-async.js';
+import { spawnAsync } from './spawn-async.ts';
 
 const fixturesRoot = fileURLToPath(new URL('../../test/fixtures', import.meta.url));
 const cliEntryPath = fileURLToPath(new URL('../../bin/pleb.js', import.meta.url));

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -14,6 +14,7 @@
     "target": "es2020",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     "lib": ["es2020"],                                   /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "libReplacement": true,                           /* Enable lib replacement. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
     // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
@@ -35,10 +36,12 @@
     "types": ["node"],                                   /* Specify type package names to be included without being referenced in a source file. */
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
-    // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
+    "allowImportingTsExtensions": true,                  /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
+    "rewriteRelativeImportExtensions": true,             /* Rewrite '.ts', '.tsx', '.mts', and '.cts' file extensions in relative import paths to their JavaScript equivalent in output files. */
     // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
     // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
     // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
+    // "noUncheckedSideEffectImports": true,             /* Check side effect imports. */
     // "resolveJsonModule": true,                        /* Enable importing .json files. */
     // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
     // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
@@ -54,12 +57,11 @@
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     "sourceMap": true,                                   /* Create source map files for emitted JavaScript files. */
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */
-    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
-    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
     // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
     // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
     // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
@@ -71,11 +73,12 @@
     // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
     // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
     // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
-    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
 
     /* Interop Constraints */
-    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    "isolatedModules": true,                             /* Ensure that each file can be safely transpiled without relying on other imports. */
     "verbatimModuleSyntax": true,                        /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
+    // "isolatedDeclarations": true,                     /* Require sufficient annotation on exports so other tools can trivially generate declaration files. */
+    "erasableSyntaxOnly": true,                          /* Do not allow runtime constructs that are not part of ECMAScript. */
     // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
     "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
@@ -88,6 +91,7 @@
     // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
     // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
     // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "strictBuiltinIteratorReturn": true,              /* Built-in iterators are instantiated with a 'TReturn' type of 'undefined' instead of 'any'. */
     // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
     // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */


### PR DESCRIPTION
- regenerate tsconfig using ts@5.8
- turn on `allowImportingTsExtensions`, `rewriteRelativeImportExtensions`, and `erasableSyntaxOnly`
- ensure all imports use .ts extensions