### PR TITLE
chore(deps): update p-queue to latest stable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@dazl/resolve-directory-context": "^5.1.0",
         "colorette": "^2.0.20",
         "commander": "^14.0.3",
-        "p-queue": "^9.1.0",
+        "p-queue": "^9.1.1",
         "promise-assist": "^2.0.1",
         "semver": "^7.7.4"
       },
@@ -1103,9 +1103,9 @@
       }
     },
     "node_modules/p-queue": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.1.0.tgz",
-      "integrity": "sha512-O/ZPaXuQV29uSLbxWBGGZO1mCQXV2BLIwUr59JUU9SoH76mnYvtms7aafH/isNSNGwuEfP6W/4xD0/TJXxrizw==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.1.1.tgz",
+      "integrity": "sha512-yQS1vV2V7Q14MQrgD8jMNY5owPuGgVHVdSK8NqmKpOVajnjbaeMa6uLOzTALPtvJ7Vo4bw0BGsw7qfUT8z24Ig==",
       "license": "MIT",
       "dependencies": {
         "eventemitter3": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@dazl/resolve-directory-context": "^5.1.0",
     "colorette": "^2.0.20",
     "commander": "^14.0.3",
-    "p-queue": "^9.1.0",
+    "p-queue": "^9.1.1",
     "promise-assist": "^2.0.1",
     "semver": "^7.7.4"
   },


### PR DESCRIPTION
Upgrade p-queue (from v9.1.0 to v9.1.1) and regenerate lock file.

https://github.com/sindresorhus/p-queue/releases/tag/v9.1.1